### PR TITLE
Fix include on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ CRC - Fast implementations of cyclic redundancy check. Six different polynomials
 Raid - calculate and operate on XOR and P+Q parity found in common RAID implementations.
 Compression - Fast deflate-compatible data compression.
 De-compression - Fast inflate-compatible data compression.
-This package includes the igzip program.
+This package includes the igzip program on Linux and MacOS.
 
 
 Current build status

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,15 +1,7 @@
-REM vcpkg install getopt
-REM if errorlevel 1 exit 1
-
-REM set INCLUDE="%INCLUDE%;%CONDA_PREFIX%\Library\share\vcpkg\installed\x86-windows\include
-
 nmake /f Makefile.nmake
 if errorlevel 1 exit 1
 
-mkdir %LIBRARY_INCLUDE%\isa-l
-if errorlevel 1 exit 1
-
-copy include\* %LIBRARY_INCLUDE%\isa-l
+xcopy include %LIBRARY_INC%\isa-l\ /E /H /F
 if errorlevel 1 exit 1
 
 copy isa-l.dll %LIBRARY_LIB%\isa-l.dll

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -9,6 +9,3 @@ if errorlevel 1 exit 1
 
 copy isa-l.lib %LIBRARY_LIB%\isa-l.lib
 if errorlevel 1 exit 1
-
-copy isa-l_static.lib %LIBRARY_LIB%\isa-l_static.lib
-if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,7 +4,7 @@ if errorlevel 1 exit 1
 xcopy include %LIBRARY_INC%\isa-l\ /E /H /F
 if errorlevel 1 exit 1
 
-copy isa-l.dll %LIBRARY_LIB%\isa-l.dll
+copy isa-l.dll %LIBRARY_BIN%\isa-l.dll
 if errorlevel 1 exit 1
 
 copy isa-l.lib %LIBRARY_LIB%\isa-l.lib

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -13,3 +13,5 @@ make install
 
 # Remove man pages
 rm -rf ${PREFIX}/share
+# Remove static library
+rm ${PREFIX}/lib/libisal.a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - nasm-filter.patch
 
 build:
-  number: 3
+  number: 4
 
 
 requirements:


### PR DESCRIPTION
Fixes a few errors on the windows recipe:

- Move the dll to the LIBRARY_BIN directory
- Use xcopy to recursively copy the include directory. (Copy failed)

Also removes static libraries from unix and windows recipes. These aren't necessary. This diminishes the package size.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
